### PR TITLE
BUG: Parenthesis Syntax Error

### DIFF
--- a/argon.rb
+++ b/argon.rb
@@ -181,7 +181,7 @@ module Argon
       @cursor = cursor.right(buffer)
     end
 
-    def store_snapshot[advance = true]
+    def store_snapshot(advance = true)
       history.save([buffer, cursor], advance)
     end
 


### PR DESCRIPTION
Was getting a syntax error because the method params were being defined with `[]` rather than `()`.